### PR TITLE
Update README.md with working URL to spark framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or possibly your `~/.bash_profile`.
 
 ## Setting Up The Java Application
 
-This application uses the lightweight [Spark Framework](www.sparkjava.com), and
+This application uses the lightweight [Spark Framework](http://sparkjava.com/), and
 requires Java 8 and [Maven](https://maven.apache.org/install.html). 
 
 Begin by creating a configuration file for your application:


### PR DESCRIPTION
Link to spark website went to a non-existant github page